### PR TITLE
Add Weapon Proficiency (Hand Crossbow) for use by Guild Thief prestig…

### DIFF
--- a/Realms.js
+++ b/Realms.js
@@ -18,7 +18,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA.
 /*jshint esversion: 6 */
 "use strict";
 
-var REALMS_VERSION = '2.2.1.1';
+var REALMS_VERSION = '2.2.1.2';
 
 /*
  * This module loads the rules from the Forgotten Realms v3 source book. The
@@ -441,6 +441,8 @@ Realms.FEATS_ADDED = {
     'Type=Fighter ' +
     'Require="features.Two Weapon Fighting",' +
             '"region =~ \'Sembia|Waterdeep|Drow Elf\'"',
+  'Weapon Proficiency (Hand Crossbow)':
+    'Type=General Require="baseAttack >= 1" Imply="weapons.Hand Crossbow"'
 };
 Realms.FEATS = Object.assign({}, SRD35.FEATS, Realms.FEATS_ADDED);
 Realms.FEATURES_ADDED = {

--- a/RealmsPrestige.js
+++ b/RealmsPrestige.js
@@ -483,9 +483,11 @@ RealmsPrestige.classRulesExtra = function(rules, name) {
 
     feats = [
       'Alertness', 'Blind-Fight', 'Cosmopolitan', 'Education', 'Leadership',
-      'Lightning Reflexes', 'Still Spell', 'Street Smart', 'Track',
-      'Weapon Finesse', 'Weapon Proficiency (Hand Crossbow)'
+      'Lightning Reflexes', 'Still Spell', 'Street Smart', 'Weapon Finesse',
+      'Weapon Proficiency (Hand Crossbow)'
     ];
+    if('Track' in allFeats)
+      feats.push('Track');
     for(var feat in allFeats) {
       if(feat.match(/(Skill|Weapon)\sFocus/))
         feats.push(feat);


### PR DESCRIPTION
…e class.

Check to see if Track feat is defined (Pathfinder doesn't have it) before using.
Fixes #15.